### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "rotating-file-stream": "^3.2.1",
     "swagger-autogen": "^2.23.7",
     "swagger-ui-express": "^5.0.1",
-    "validator": "^13.12.0"
+    "validator": "^13.12.0",
+    "express-rate-limit": "^8.0.0"
   },
   "devDependencies": {
     "clean-jsdoc-theme": "^4.3.0",

--- a/routers/infoRouter.js
+++ b/routers/infoRouter.js
@@ -11,7 +11,12 @@ const fs = require('fs');
 const fsPromises = require('fs').promises;
 const path = require('path');
 const express = require('express');
+const RateLimit = require('express-rate-limit'); // Import express-rate-limit
 const router = express.Router();
+const openapi3Limiter = RateLimit({ // Define rate limiter for `/openapi3`
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+});
 router.use(express.json());
 
 /**
@@ -103,7 +108,7 @@ const health = router.get('/health', (req, res) => {
  * 200 - OpenApi3 JSON
  * 500 - Missing Swagger File
  */
-const swagger = router.get('/openapi3', (req, res) => {
+const swagger = router.get('/openapi3', openapi3Limiter, (req, res) => {
   /*
     #swagger.summary = 'OpenApi3 JSON Definition (swagger)'
     #swagger.responses[200] = {


### PR DESCRIPTION
Potential fix for [https://github.com/BlitzkriegSoftware/NodeJsPersonApi/security/code-scanning/5](https://github.com/BlitzkriegSoftware/NodeJsPersonApi/security/code-scanning/5)

To address the missing rate limiting issue, we will use the `express-rate-limit` package to introduce rate limiting for the `/openapi3` endpoint. This ensures that the endpoint is protected against abuse and prevents denial-of-service attacks.

#### Steps:
1. Install the `express-rate-limit` package, which is widely used for implementing rate limiting in Express applications.
2. Define a rate limiter middleware with reasonable limits (e.g., 100 requests per 15 minutes).
3. Apply the rate limiter middleware specifically to the `/openapi3` endpoint.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
