### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/routers/infoRouter.js
+++ b/routers/infoRouter.js
@@ -29,7 +29,7 @@ router.use(express.json());
  * 200 - Info
  * 500 - Missing Critical File
  */
-const about = router.get('/about', (req, res) => {
+const about = router.get('/about', openapi3Limiter, (req, res) => {
   /*
     #swagger.summary = 'About this API'
     #swagger.responses[200] = {


### PR DESCRIPTION
Potential fix for [https://github.com/BlitzkriegSoftware/NodeJsPersonApi/security/code-scanning/3](https://github.com/BlitzkriegSoftware/NodeJsPersonApi/security/code-scanning/3)

Use `express-rate-limit` middleware on the `/about` route (the flagged handler) so repeated requests from a client are capped over a time window. This preserves functionality while adding protection against request floods that trigger filesystem reads.

Best fix in this snippet:
- Reuse the already-created `openapi3Limiter` (same dependency, same file, no behavior change to response payloads).
- Apply it as route middleware to `/about` exactly like `/swagger` already does.
- Edit only `routers/infoRouter.js`, at the `/about` route declaration line.

No new imports or new dependencies are required because `express-rate-limit` is already imported and configured.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
